### PR TITLE
New command - elm.browsePackage

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,10 @@
         "title": "Elm: Install packages/dependencies"
       },
       {
+        "command": "elm.browsePackage",
+        "title": "Elm: Browse packages/dependencies documentation"
+      },
+      {
         "command": "elm.clean",
         "title": "Elm: Clean build artifact"
       }
@@ -196,6 +200,7 @@
     "onCommand:elm.replStart",
     "onCommand:elm.reactorStart",
     "onCommand:elm.install",
+    "onCommand:elm.browsePackage",
     "onCommand:elm.clean"
   ],
   "main": "./out/src/elmMain",
@@ -209,8 +214,11 @@
     "vscode": "^0.10.7"
   },
   "dependencies": {
-    "rimraf": "^2.5.2",
     "elm-oracle": "^0.2.0",
-    "request": "^2.69.0"
+    "mac-open": "^0.1.3",
+    "open": "0.0.5",
+    "request": "^2.69.0",
+    "rimraf": "^2.5.2",
+    "vscode-uri": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -214,11 +214,9 @@
     "vscode": "^0.10.7"
   },
   "dependencies": {
-    "elm-oracle": "^0.2.0",
-    "mac-open": "^0.1.3",
-    "open": "0.0.5",
-    "request": "^2.69.0",
     "rimraf": "^2.5.2",
+    "elm-oracle": "^0.2.0",
+    "request": "^2.69.0",
     "vscode-uri": "^1.0.0"
   }
 }

--- a/src/elmPackage.ts
+++ b/src/elmPackage.ts
@@ -1,10 +1,6 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { execCmd } from './elmUtils';
 const request = require('request');
-const open = require('open');
-const open_darwin = require('mac-open');
-const platform = process.platform;
 
 let oc: vscode.OutputChannel = vscode.window.createOutputChannel('Elm Package');
 
@@ -29,11 +25,7 @@ function browsePackage(): Thenable<void> {
           let uri = selectedVersion
             ? vscode.Uri.parse("http://package.elm-lang.org/packages/" + selectedPackage.label + "/" + selectedVersion.label)
             : vscode.Uri.parse("http://package.elm-lang.org/packages/" + selectedPackage.label + "/latest")
-          if (platform === 'darwin') {
-            open_darwin(uri.toString())
-          } else {
-            open(uri.toString())
-          }
+          vscode.commands.executeCommand("vscode.open", uri, 3);
         });
     });
 }
@@ -97,7 +89,7 @@ function getJSON(): Thenable<any[]> {
 }
 
 function transformToQuickPickItems(json: any[]): vscode.QuickPickItem[] { 
-  return json.map(item => ({ label: item.name, description: item.summary,  }));
+  return json.map(item => ({ label: item.name, description: item.summary }));
 }
 
 export function activatePackage(): vscode.Disposable[] {


### PR DESCRIPTION
I found myself looking up elm package documentation on a very frequent basis, switching between VsCode and my browser. I thought to myself: "Wouldn't it be cool if you could navigate to the documentation of a package from within VsCode?". I forked this codebase and figured I'd give it a go. Being a total noob at both javascript and typescript didn't stop me from achieving my goal.

### Couple of things
- I'm not sure whether this is a useful addition. That's for the maintainers to decide.
- A review would be most welcome (noob, remember). I've tried it out on Windows, so if somebody on Linux or MacOS would like to give it a go, that would be much appreciated.
- I'm not sure where the best place is to document this further. Please advice.