### PR TITLE
Handling null results from elmOracle

### DIFF
--- a/src/elmInfo.ts
+++ b/src/elmInfo.ts
@@ -5,7 +5,7 @@ export class ElmHoverProvider implements vscode.HoverProvider {
   public provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Hover> {
     return oracle.GetOracleResults(document, position)
       .then((result) => {
-        if (result.length > 0) {
+        if (result && result.length > 0) {
           let text =  this.formatSig(result[0].signature) + '\n\n' + result[0].comment;
           let hover = new vscode.Hover(text);
           return hover;
@@ -15,11 +15,11 @@ export class ElmHoverProvider implements vscode.HoverProvider {
         }})
   }
   private formatSig(signature: String): String {
-    return '~~~\n' 
+    return '~~~\n'
       + signature
         .replace(/\{/g, '  {')        //spaces before open brace
         .replace(/\s?,/g, '\n  ,')    //newlines + spaces before comma
-        .replace(/\}\s?/g, '\n  }\n') //newline + spaces before close brace + newline after  
+        .replace(/\}\s?/g, '\n  }\n') //newline + spaces before close brace + newline after
       + '\n~~~';
   }
 }


### PR DESCRIPTION
I found some error causing problem with search field in VSCode, so I took a look on it and found this in console. And this small fix can fix it. 
<img width="1133" alt="vscode-elm-error" src="https://cloud.githubusercontent.com/assets/5626634/25697389/12ca66c4-30bb-11e7-9b09-828b0349aa98.png">

As I found, elmOracle could return null result so there is no needs to find reason of null result now and should be handled this way.