### PR TITLE
Fix for elm-oracle being fed entire elm file

### DIFF
--- a/src/elmOracle.ts
+++ b/src/elmOracle.ts
@@ -26,6 +26,9 @@ export function GetOracleResults(document: vscode.TextDocument, position: vscode
       let cwd = detectProjectRoot(document.fileName) || vscode.workspace.rootPath;
       let fn = path.relative(cwd, filename)
       let wordAtPosition = document.getWordRangeAtPosition(position);
+      if (!wordAtPosition) {
+        return resolve (null);
+      }
       let currentWord: string = document.getText(wordAtPosition);
       let oracleCmd = oraclePath + ' "' + fn + '" ' + currentWord;
        

--- a/src/elmOracle.ts
+++ b/src/elmOracle.ts
@@ -30,9 +30,8 @@ export function GetOracleResults(document: vscode.TextDocument, position: vscode
         return resolve (null);
       }
       let currentWord: string = document.getText(wordAtPosition);
-      let oracleCmd = oraclePath + ' "' + fn + '" ' + currentWord;
        
-      p = cp.exec('node ' + oracleCmd, { cwd: cwd }, (err: Error, stdout: Buffer, stderr: Buffer) => {
+      p = cp.execFile('node', [oraclePath, fn, currentWord] , { cwd: cwd }, (err: Error, stdout: Buffer, stderr: Buffer) => {
         try {
           if (err) {
             return resolve(null);


### PR DESCRIPTION
This is a fix for #93 which was an unfortunate combination of mishandling a null result from getWordRangeAtPosition, and using child_process.exec instead of child_process.execFile. We previously fed the null result into document.getText, which returned the entire document, then appended that string onto a shell command, which meant that most of the elm file being examined was sent out to be interpreted by the shell. In the case spelled out by #93 , this just meant that the "import" program was called (which took a screenshot if ImageMagick was installed), but it could have been much worse!