### PR TITLE
Fixes duplicate module name in autocomplete

### DIFF
--- a/src/elmAutocomplete.ts
+++ b/src/elmAutocomplete.ts
@@ -21,7 +21,7 @@ export class ElmCompletionProvider implements vscode.CompletionItemProvider {
           if (currentWord.substr(-1) === '.') {
             ci.textEdit = {
               range: new vscode.Range(position, position),
-              newText: v.fullName.trim()
+              newText: v.fullName.trim().substr(currentWord.length)
             };
           }
 


### PR DESCRIPTION
Fixes the duplicate module name for autocomplete - fix for issue #123

I'm not sure if this would break any existing autocomplete functionality, but limited testing with module names seems to work ok.