### PR TITLE
Autocomplete handles aliased module names

### DIFF
--- a/src/elmAutocomplete.ts
+++ b/src/elmAutocomplete.ts
@@ -19,9 +19,11 @@ export class ElmCompletionProvider implements vscode.CompletionItemProvider {
           ci.detail = v.signature;
           ci.documentation = v.comment;
           if (currentWord.substr(-1) === '.') {
+            let fullNameSplit = v.fullName.trim().split('.');
+            let lastWordFullName = fullNameSplit[fullNameSplit.length - 1];
             ci.textEdit = {
               range: new vscode.Range(position, position),
-              newText: v.fullName.trim().substr(currentWord.length)
+              newText: lastWordFullName
             };
           }
 

--- a/src/elmUserProject.ts
+++ b/src/elmUserProject.ts
@@ -45,15 +45,33 @@ export function userProject(document: vscode.TextDocument, position: vscode.Posi
     if (match = lines[i].match(/^import/)) {
       let exposingMatch;
       if (exposingMatch = lines[i].match(/exposing \(/)) {
-        imports.push({
-          module: lines[i].split(' ')[1],
-          exposing: exposingList(lines[i].split('(')[1].replace(')', ''))
-        });
+        let asMatch;
+        if (asMatch = lines[i].match(/as/)) {
+          imports.push({
+            module: lines[i].split(' ')[3],
+            exposing: exposingList(lines[i].split('(')[1].replace(')', ''))
+          });
+        }
+        else {
+          imports.push({
+            module: lines[i].split(' ')[1],
+            exposing: exposingList(lines[i].split('(')[1].replace(')', ''))
+          });
+        }
       } else {
-        imports.push({
-          module: lines[i].split(' ')[1],
-          exposing: []
-        });
+        let asMatch;
+        if (asMatch = lines[i].match(/as/)) {
+          imports.push({
+            module: lines[i].split(' ')[3],
+            exposing: []
+          });
+        }
+        else {
+          imports.push({
+            module: lines[i].split(' ')[1],
+            exposing: []
+          });
+        }
       }
     } else if (lines[i].trim() !== '' && !lines[i].match(/^module/)) {
       break;


### PR DESCRIPTION
If aliased with "as", the alias will be used in autocomplete. Fixes issue #96 