### PR TITLE
Elm-format error as StatusBar instead of ErrorMessage

### DIFF
--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -17,11 +17,12 @@ const ELM_MODE: vscode.DocumentFilter = { language: 'elm', scheme: 'file' };
 
 // this method is called when your extension is activated
 export function activate(ctx: vscode.ExtensionContext) {
+  const elmFormatStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
   ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
     runLinter(document);
   }));
   ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
-    runFormatOnSave(document);
+    runFormatOnSave(document, elmFormatStatusBar);
   }));
   activateRepl().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
   activateReactor().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
@@ -33,7 +34,7 @@ export function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELM_MODE, new ElmHoverProvider()));
   ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), '.'));
   ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(ELM_MODE, new ElmSymbolProvider()));
-  ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(ELM_MODE, new ElmFormatProvider()))
+  ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(ELM_MODE, new ElmFormatProvider(elmFormatStatusBar)))
 
   // ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELM_MODE, new ElmDefinitionProvider()));
 }


### PR DESCRIPTION
When using Elm-format on save, errors from Elm-format would show the error as an error message and user needs to click ok to dismiss the message. I found it annoying and wanted to try a more discrete solution. This shows the error in the status bar. The status bar is a statusbar item only used by Elm-format and is hidden on each run. I'm not sure if we also need to hide this status bar on any other events.

Old functionality:
![image](https://cloud.githubusercontent.com/assets/367175/26677006/56c900cc-46ca-11e7-9357-16bc9a80a772.png)

New functionality:
![image](https://cloud.githubusercontent.com/assets/367175/26676952/13fd05cc-46ca-11e7-9bf4-9e370d9f8d53.png)
-where this message is hidden on next save in elm-format