### PR TITLE
Initial implementation of CodeActions

### DIFF
--- a/src/elmCodeAction.ts
+++ b/src/elmCodeAction.ts
@@ -1,0 +1,140 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import { TextEditor, window, workspace } from 'vscode'
+
+export class ElmCodeActionProvider implements vscode.CodeActionProvider {
+	public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Thenable<vscode.Command[]> {
+		let wordRange = document.getWordRangeAtPosition(range.start);
+		let currentWord: string = document.getText(wordRange);
+		let currentWordPrefix = currentWord.substring(0, currentWord.lastIndexOf('.'));
+		let currentWordSuffix = currentWord.substr(currentWord.lastIndexOf('.') + 1);
+		let annotationWordCriteria = 'Top-level value `' + currentWord + '` does not have a type annotation. - I inferred the type annotation so you can copy it into your code:';
+		let modelFieldMissingCriteria = 'Hint: The record fields do not match up. Maybe you made one of these typos?'
+
+		let suggestionsCriterias = [
+			'Cannot find variable `' + currentWord + '` - Maybe you want one of the following?',
+			'Cannot find variable `' + currentWord + '`. - `' + currentWordPrefix + '` does not expose `' + currentWordSuffix + '`. Maybe you want one of the following?',
+			'Cannot find variable `' + currentWord + '`. - No module called `' + currentWordPrefix + '` has been imported. Maybe you want one of the following?',
+			'Cannot find pattern `' + currentWord + '`. - `' + currentWordPrefix + '` does not expose `' + currentWordSuffix + '`. Maybe you want one of the following?',
+			'Cannot find pattern `' + currentWord + '` - Maybe you want one of the following?',
+			'Cannot find type `' + currentWord + '` - Maybe you want one of the following?',
+			'Cannot find type `' + currentWord + '`. - `' + currentWordPrefix + '` does not expose `' + currentWordSuffix + '`. Maybe you want one of the following?'
+		]
+
+		let promises = context.diagnostics.map(diag => {
+			if (diag.message.indexOf(annotationWordCriteria) >= 0) {
+				return [
+					{
+						title: 'Add function type annotation',
+						command: 'elm.codeActionAnnotateFunction',
+						arguments: [diag.message.substr(annotationWordCriteria.length + 1).trim()]
+					}
+				];
+			}
+			else if (suggestionsCriterias.some(function(v) { return diag.message.indexOf(v) >= 0; })) {
+				let suggestions = diag.message.substr(diag.message.indexOf('\n')).trim();
+				let commands = suggestions
+					.split('\n')
+					.map(val => val.trim())
+					.map(val => {
+						return {
+							title: 'Change to: ' + val,
+							command: 'elm.codeActionReplaceSuggestedVariable',
+							arguments: [[currentWord, val]]
+						}
+					});
+				return commands;
+			}
+			else if (diag.message.indexOf(modelFieldMissingCriteria) >= 0) {
+				let modelName = currentWord.substring(0, currentWord.indexOf('.') + 1);
+				let message = diag.message.split('\n');
+				let suggestions = message[message.length - 1].trim().split('<->');
+
+				let commands = suggestions
+					.map(val => modelName + val.trim())
+					.map(val => {
+						return {
+							title: 'Change to: ' + val,
+							command: 'elm.codeActionReplaceSuggestedVariable',
+							arguments: [[currentWord, val]]
+						}
+					});
+				return commands;
+			}
+			return [];
+		});
+
+		return Promise.all(promises).then(arrs => {
+			let results = {};
+			for (let segment of arrs) {
+				for (let item of segment) {
+					results[item.title] = item;
+				}
+			}
+			let ret = [];
+			for (let title of Object.keys(results).sort()) {
+				ret.push(results[title]);
+			}
+			return ret;
+		});
+	}
+}
+
+function annotateFunction(msg : string) {
+	let editor = vscode.window.activeTextEditor;
+	if (!editor) {
+		vscode.window.showInformationMessage('No editor is active.');
+		return;
+	}
+  if (editor.document.languageId !== 'elm') {
+		vscode.window.showInformationMessage('Language is not Elm');
+    return;
+  }
+	let position = vscode.window.activeTextEditor.selection.active
+	let wordRange = editor.document.getWordRangeAtPosition(position);
+	let currentWord: string = editor.document.getText(wordRange);
+	let msgList = msg.split('\n');
+	if (msgList.length > 1) {
+		let annotation = msgList
+			.map((val: string) => val.trim())
+		  .join(' ');
+		editor.edit(editBuilder => {
+			editBuilder.insert(position.translate(-1), annotation);
+		});
+	}
+	else {
+		vscode.window.showInformationMessage('Could not resolve function type annotation');
+	}
+}
+
+function replaceSuggestedVariable(msg : string[]) {
+	let editor = vscode.window.activeTextEditor;
+	if (!editor) {
+		vscode.window.showInformationMessage('No editor is active.');
+		return;
+	}
+  if (editor.document.languageId !== 'elm') {
+		vscode.window.showInformationMessage('Language is not Elm');
+    return;
+  }
+	let position = vscode.window.activeTextEditor.selection.active
+	let wordRange = editor.document.getWordRangeAtPosition(position);
+	let currentWord: string = editor.document.getText(wordRange);
+	if (msg.length == 2 && msg[0] == currentWord){
+		editor.edit(editBuilder => {
+			editBuilder.replace(wordRange, msg[1]);
+		});
+	}
+	else {
+		vscode.window.showInformationMessage('Could not find variable to replace');
+	}
+}
+
+
+export function activateCodeActions(): vscode.Disposable[] {
+  return [
+    vscode.commands.registerCommand('elm.codeActionAnnotateFunction', (msg) => annotateFunction(msg)),
+		vscode.commands.registerCommand('elm.codeActionReplaceSuggestedVariable', (msg) => replaceSuggestedVariable(msg))
+  ];
+}

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -10,6 +10,7 @@ import {ElmDefinitionProvider} from './elmDefinition';
 import {ElmHoverProvider} from './elmInfo';
 import {ElmCompletionProvider} from './elmAutocomplete';
 import {ElmSymbolProvider} from './elmSymbol';
+import {ElmCodeActionProvider, activateCodeActions} from './elmCodeAction';
 import {configuration} from './elmConfiguration';
 import {ElmFormatProvider, runFormatOnSave} from './elmFormat';
 
@@ -28,12 +29,14 @@ export function activate(ctx: vscode.ExtensionContext) {
   activateMake().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
   activatePackage().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
   activateClean().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
+  activateCodeActions().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
 
   ctx.subscriptions.push(vscode.languages.setLanguageConfiguration('elm', configuration))
   ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELM_MODE, new ElmHoverProvider()));
   ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), '.'));
   ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(ELM_MODE, new ElmSymbolProvider()));
   ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(ELM_MODE, new ElmFormatProvider()))
+  ctx.subscriptions.push(vscode.languages.registerCodeActionsProvider(ELM_MODE, new ElmCodeActionProvider()));
 
   // ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELM_MODE, new ElmDefinitionProvider()));
 }


### PR DESCRIPTION
I've tried to implement some code actions for function type annotations, misspelled variable names, types and patterns. Not sure if this is the best way to implement this, by pattern matching on different code diagnostics. Suggestions are welcome.

For any implemented suggestion, a the lightbulb will appear and able to click/ctrl+. to show suggestions:

For function type annotation:
![image](https://cloud.githubusercontent.com/assets/367175/26726019/9c342c18-47a1-11e7-9fa8-3b189f2197c4.png)

Patterns:
![image](https://cloud.githubusercontent.com/assets/367175/26726081/edfebb6c-47a1-11e7-8198-e716cb5697d0.png)

Variables:
![image](https://cloud.githubusercontent.com/assets/367175/26726265/94ee9776-47a2-11e7-8704-e7998704b535.png)
![image](https://cloud.githubusercontent.com/assets/367175/26726943/325b191a-47a5-11e7-8d60-3b2e3c1c1240.png)
