### PR TITLE
Implements go to/show definition for document

### DIFF
--- a/src/elmDefinition.ts
+++ b/src/elmDefinition.ts
@@ -1,15 +1,50 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import {ElmSymbolProvider} from './elmSymbol';
+import { Position, Range, SymbolInformation, SymbolKind, TextDocument, TextLine } from 'vscode';
+
+
+export function definitionLocation(document: vscode.TextDocument, position: vscode.Position): Promise<SymbolInformation> {
+  let wordRange = document.getWordRangeAtPosition(position);
+  let lineText = document.lineAt(position.line).text;
+  let word = wordRange ? document.getText(wordRange) : '';
+
+  // also check keywords, in-string etc.
+  if (!wordRange || lineText.startsWith('--') || word.match(/^\d+.?\d+$/) ) {
+  	return Promise.resolve(null);
+  }
+  var symbolProvider = new ElmSymbolProvider();
+
+  return symbolProvider.provideDocumentSymbols(document, "")
+    .then(definitions => {
+      if (definitions == null) return Promise.resolve(null);
+      let filteredDefinitions = definitions
+        .filter((val, index, arr) => val.name == word);
+      if (filteredDefinitions.length > 0) {
+        return filteredDefinitions[0];
+      }
+      else {
+  	  return Promise.resolve(null);
+      }
+    }, err => {
+  	  return Promise.resolve(null);
+    }
+  );
+}
 
 export class ElmDefinitionProvider implements vscode.DefinitionProvider {
-  public provideDefinition(document: vscode.TextDocument, position: vscode.Position,
-                           token: vscode.CancellationToken): Thenable<vscode.Location> {
-    return new Promise((resolve, reject) => {
-      // with the definition provider you can jump e.g. to the declaration of a file
-      // there's nothing like godef in elm. we need to figure out how to do this
-      // leaving this file here due to bad VS Code documentation atm
-      resolve();
-    });
+  public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Location> {
+		return definitionLocation(document, position).then(definitionInfo => {
+			if (definitionInfo == null || definitionInfo.location == null) return null;
+      let definitionResource = document.uri;
+			let pos = new vscode.Position(definitionInfo.location.range.start.line, 0);
+			return new vscode.Location(definitionResource, pos);
+		}, err => {
+			if (err) {
+				console.log(err);
+			}
+			return Promise.resolve(null);
+		});
   }
 }

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -33,7 +33,8 @@ export function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELM_MODE, new ElmHoverProvider()));
   ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), '.'));
   ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(ELM_MODE, new ElmSymbolProvider()));
-  ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(ELM_MODE, new ElmFormatProvider()))
+  ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(ELM_MODE, new ElmFormatProvider()));
+  ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELM_MODE, new ElmDefinitionProvider()));
 
   // ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELM_MODE, new ElmDefinitionProvider()));
 }


### PR DESCRIPTION
Initial implementation. Use F12 or "Go to Definition" to navigate to symbol in document. This should resolve issue #45.

This implementation uses the existing ElmSymbolProvider to resolve document symbols. Is this a correct implementation? For workspace, I assume we need a workspace symbol provider?