### PR TITLE
Fix elm-make to use path correctly. Also introduce special file config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
           "default": "elm-make",
           "description": "Command to run when executing elm-make"
         },
+        "elm.makeSpecialFile": {
+          "type": "string",
+          "default": "",
+          "description": "When empty, the elm-make uses the current editor file. If set, elm-make always use this file. Example 'src/Main.elm' will run elm-make on workspacepath/src/Main.elm"
+        },
         "elm.formatOnSave": {
           "type": "boolean",
           "default": false,

--- a/src/elmMake.ts
+++ b/src/elmMake.ts
@@ -15,12 +15,17 @@ function execMake(editor : vscode.TextEditor, warn : boolean) : void {
       make.kill();
       oc.clear();
     }
-    const file = editor.document.fileName;
+    let file = editor.document.fileName;
     const cwd: string = utils.detectProjectRoot(file) || vscode.workspace.rootPath;
     
     const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
     const name: string = <string>config.get('makeOutput');
-    const makeCommand: string = path.resolve(cwd, <string>config.get('makeCommand'));
+    const specialFile: string = <string>config.get('makeSpecialFile');
+    const makeCommand: string = <string>config.get('makeCommand');
+    if (specialFile.length > 0) {
+      file = path.resolve(cwd, specialFile);
+    }
+
     let args = [file, '--yes', '--output=' + name];
     if (warn) {
       args.push("--warn");


### PR DESCRIPTION
Changed elm-make command to use only the configured command from settings (default: elm-make). It then base the execution on the users path for elm-make. This is overrideable by changing the makeCommand setting. This fixes issue #121, the existing implementation creates a path as workspacepath/elm-make.

I also introduced a setting for elm-make to point to a special file/location in the workspace - useful when you don't want to open the Main.elm file to be able to run elm-make successfully. 