### PR TITLE
Function comments now included in intellisense. Bugfixes for hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
           "type": "string",
           "default": "**/{node_modules,elm-stuff}/**",
           "description": "The exclude pattern used to search in workspace when reading workspace symbols."
+        },
+        "elm.includeUserFunctionDocumentation": {
+          "type": "boolean",
+          "default:": true,
+          "description": "Include function/type/type alias comments in intellisense results."
         }
       }
     },

--- a/src/elmInfo.ts
+++ b/src/elmInfo.ts
@@ -8,6 +8,17 @@ export class ElmHoverProvider implements vscode.HoverProvider {
     return oracle.GetOracleResults(document, position, oracle.OracleAction.IsHover)
       .then((result) => {
         if (result && result.length > 0) {
+          if (result.length > 1) {
+            let wordAtPosition = document.getWordRangeAtPosition(position);
+            if (wordAtPosition) {
+              let currentWord: string = document.getText(wordAtPosition);
+              let exactMatches = result.filter(item => item.name === currentWord);
+              if (exactMatches.length > 0) {
+                result = exactMatches;
+              }
+            }
+          }
+          
           let text =  this.formatSig(result[0].signature) + '\n\n' + result[0].comment;
           let hover = new vscode.Hover((config['showSuggestionsInElmSyntax'] ? { language: 'elm', value: text } : text));
           return hover;

--- a/src/elmUserProject.ts
+++ b/src/elmUserProject.ts
@@ -114,7 +114,7 @@ function getFunctionComments(lines: string[]): string {
     if (config["includeUserFunctionDocumentation"] !== true) { return documentation; }
     let inComment = false;
     for (let j = lines.length-1; j >= 0; j--) {
-      if (lines[j].trim() == '') { break; }
+      if (lines[j].trim() == '' && !inComment) { break; }
       if (lines[j].includes('-}')) {
         inComment = true;
       }


### PR DESCRIPTION
Summary: Fixed bugs in parsing elm-oracle hover results and bugs in userProject hover results.  Added ability to include function documentation in hover/autocomplete.

This fixes issue #146 which was caused by multiple results being returned for a hover request, but only the first entry being displayed.
The solution was to filter the returned results in elmInfo and only keep them where the current word exactly matched the 'name' property. This eliminated partial matches such as Html.Attribute.List when 'li' is hovered.

While investigating this I realized that the user project hover support can easily return multiple results so I modified it to not set the 'name' to be the currentWord but instead only include if the line begins with the hovered word.  This prevented cases where a String was passed to a custom type and therefore any time String was hovered it would suggest that custom type.
Now, if you hover over MyTypeValue and a file includes

type  MyType
= FirstType Int
| MyTypeValue String

You will get the intellisense for MyType and MyTypeValue.  If you instead hover over the 'String' in

someOtherFunction : String -> Int

You will NOT get the intellisense results for MyType.  

**New Feature:**
Added the ability to include function/type/type alias comments in intellisense.  This is controlled by setting elm.includeUserFunctionDocumentation and is true by default.  This works by walking back up in a file after finding a function definition or type signature and including all lines between {-| and -}. Once an empty line is encountered or it reaches the beginning of the file, the comment stops.
Requested in issue #122