### PR TITLE
WIP - Initial json-to-elm implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,14 @@
       {
         "command": "elm.clean",
         "title": "Elm: Clean build artifact"
+      },
+      {
+        "command": "elm.createJsonDecoderFromSelection",
+        "title": "Elm: Create Json Decoder from selection"
+      },
+      {
+        "command": "elm.createJsonEncoderFromSelection",
+        "title": "Elm: Create Json Encoder from selection"
       }
     ],
     "outputChannels": [
@@ -245,7 +253,8 @@
     "onCommand:elm.reactorStart",
     "onCommand:elm.install",
     "onCommand:elm.browsePackage",
-    "onCommand:elm.clean"
+    "onCommand:elm.clean",
+    "onCommand:elm.createJsonDecoderFromSelection"
   ],
   "main": "./out/src/elmMain",
   "scripts": {

--- a/src/elmJson.ts
+++ b/src/elmJson.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { detectProjectRoot } from './elmUtils';
+import {GeneratorType, createDecoder, createEncoder, createEverything} from './elmJsonToElm';
+
+
+function createJsonEncoderDecoderFromSelection(editor: vscode.TextEditor, generatorType : GeneratorType) {
+  const toplevelAliasDialogOptions: vscode.InputBoxOptions = { placeHolder: 'Example: User', prompt: 'Please enter toplevel alias name', value: 'Something' };
+  try {
+    let selection = editor.selection;
+    let selectionText = editor.document.getText(selection);
+    let validJsonString = JSON.parse(selectionText);
+    let outputChoices = [
+      'Output to new file',
+      'Output to bottom of an existing file',
+      'Output into bottom of current file'
+    ];
+    let result = vscode.window.showInputBox(toplevelAliasDialogOptions)
+      .then(okInput => {
+        if (okInput !== undefined) {
+          let generatedCode = createEverything(selectionText, okInput, true, generatorType);
+          vscode.window.showQuickPick(outputChoices)
+            .then(outputChoice => {
+              if (outputChoice !== undefined) {
+                if (outputChoice == outputChoices[2]) { // this file
+                  insertIntoCurrentFileFromResult(generatedCode, editor); 
+                }
+                else if (outputChoice == outputChoices[0]) { // new file
+                  createNewFileFromResult(generatedCode, editor.document); 
+                }
+                else if (outputChoice == outputChoices[1]) { //existing file
+                  insertIntoExistingFileFromResult(generatedCode);
+                }
+              }
+              else {
+                console.log('Choice canceled');
+              }
+            }
+          )
+        }
+        else {
+          vscode.window.showErrorMessage('Canceled or invalid toplevel alias name. Aborted json-to-elm.');
+        }
+      }, err => {
+        console.log('err');
+    })
+  }
+  catch (e) {
+    if (e.message.startsWith('Unexpected token')) {
+      vscode.window.showErrorMessage('Running Elm Create Json Decoder failed. This does not seem to be valid json');
+    }
+    else {
+      vscode.window.showErrorMessage('Running Elm Create Json Decoder failed');
+    }
+  }
+}
+
+function createNewFileFromResult(fileInput: string, document: vscode.TextDocument) {
+  let root = detectProjectRoot(document.uri.fsPath);
+  let filePath = path.join(root, 'Please-choose-save-as-new-file-name.elm')
+  var setting: vscode.Uri = vscode.Uri.parse("untitled:" + filePath);
+  const openTextSettings : any = {language: 'elm'} // Set to any type to disable old vscode dev version warning
+  vscode.workspace.openTextDocument(openTextSettings).then((a: vscode.TextDocument) => {
+      vscode.window.showTextDocument(a).then(e => {
+          e.edit(edit => {
+              edit.insert(new vscode.Position(0, 0), fileInput);
+          });
+      });
+  }, (error: any) => {
+      console.error(error);
+      debugger;
+  });
+}
+
+function insertIntoCurrentFileFromResult(fileInput: string, editor: vscode.TextEditor) {
+  editor.edit(edit => {
+      edit.insert(new vscode.Position(editor.document.lineCount + 1, 0), '-- Created with json-to-elm\n\n' + fileInput);
+  });
+}
+
+function insertIntoExistingFileFromResult(fileInput: string) {
+  const config = vscode.workspace.getConfiguration('elm');
+  let maxFiles = config['maxWorkspaceFilesUsedBySymbols'];
+  let excludePattern = config['workspaceFilesExcludePatternUsedBySymbols'];
+  let docs = vscode.workspace.findFiles('**/*.elm', excludePattern, maxFiles)
+    .then(workspaceFiles => {
+      const uris = workspaceFiles.map(value => value.fsPath)
+      vscode.window.showQuickPick(uris, {placeHolder:'Choose one of the existing files in your workspace..'})
+        .then(selectedFile => {
+          if (selectedFile !== undefined) {
+            vscode.workspace.openTextDocument(selectedFile)
+              .then(openedFile => {
+                let workspaceEdit = new vscode.WorkspaceEdit();
+                const edit = workspaceEdit.insert(openedFile.uri, new vscode.Position(openedFile.lineCount +1, 0),'-- Created with json-to-elm\n\n' + fileInput)
+                vscode.workspace.applyEdit(workspaceEdit);
+                vscode.window.showTextDocument(openedFile);
+            })
+          }
+      })
+    }
+  )
+}
+
+function runCreateJsonDecoderFromSelection(editor: vscode.TextEditor) {
+  createJsonEncoderDecoderFromSelection(editor, GeneratorType.Decoder);
+}
+
+function runCreateJsonEncoderFromSelection(editor: vscode.TextEditor) {
+  createJsonEncoderDecoderFromSelection(editor, GeneratorType.Encoder);
+}
+
+export function activateJson(): vscode.Disposable[] {
+  return [
+    vscode.commands.registerTextEditorCommand('elm.createJsonDecoderFromSelection', runCreateJsonDecoderFromSelection),
+    vscode.commands.registerTextEditorCommand('elm.createJsonEncoderFromSelection', runCreateJsonEncoderFromSelection)
+  ];
+}

--- a/src/elmJsonToElm.ts
+++ b/src/elmJsonToElm.ts
@@ -1,0 +1,209 @@
+// Temporary copy from https://github.com/eeue56/json-to-elm
+// Until agreed on how to use json-to-elm as a package / library
+// Testing json-to-elm in vscode-elm extension
+
+export enum GeneratorType {
+  Decoder = 1,
+  Encoder
+}
+
+var KNOWN_DECODERS = [
+    'maybe',
+    'list' ,
+    'int' ,
+    'float' ,
+    'bool',
+    'string' ];
+
+var isInt = function(n) {
+   return n % 1 === 0;
+};
+
+var makeGuessAtType = function(item) {
+    if (item === null) {
+        return 'Maybe _Unknown';
+    }
+
+    var type = typeof(item);
+
+    if (type === 'boolean'){
+        return 'Bool';
+    }
+
+    if (type === 'string'){
+        return 'String';
+    }
+
+    if (type === 'number'){
+        if (isInt(item)){
+            return 'Int';
+        }
+
+        return 'Float';
+    }
+
+    if (Array.isArray(item)){
+        if (item.length === 0){
+            return 'List a';
+        }
+
+        return 'List ' + makeGuessAtType(item[0]);
+    }
+
+    if (type === 'object'){
+        return 'Something';
+    }
+
+    return 'Unknown';
+};
+
+var capitalize = function(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+var createTypeAlias = function(stuff, typeAliasName){
+    var extraAliases = [];
+
+    var fields = Object.keys(stuff).map(function(name){
+        let value = stuff[name];
+        let type = makeGuessAtType(value)
+
+        if (type === 'Something'){
+            extraAliases = extraAliases.concat(createTypeAlias(value, typeAliasName=capitalize(name)));
+            type = capitalize(name);
+        }
+
+        return `${name} : ${type}`;
+    }).join("\n    , ");
+
+    extraAliases.push(`type alias ${typeAliasName} =\n    { ${fields}\n    }`);
+
+    return extraAliases;
+};
+
+
+var getTypeAliasName = function(string){
+    var grabTypeNames = string.match(/type alias(.+)\=/g);
+
+    if (grabTypeNames === null || grabTypeNames.length === 0){
+        return; //   raise Exception("Can't find type alias declaration")
+    }
+
+    if (grabTypeNames.length > 1){
+        return "Please only give me one type alias at a time";
+    }
+
+    return grabTypeNames[0].split('type alias')[1].split('=')[0].trim();
+};
+
+
+var getFields = function(string){
+    string = string.replace(/\n/g, '');
+
+    var grab_fields = string.match(/\{.+\}/mg)
+    var first = grab_fields[0].replace(/[{}]/g, '').trim();
+
+    return first.split(',');
+};
+
+var fieldNameAndType = function(string){
+    var splitted = string.split(':');
+
+    return {
+        name: splitted[0].trim(),
+        type: splitted[1].trim()
+    };
+};
+
+var makeGuessAtDecoder = function(string) {
+    return string.toLowerCase();
+};
+
+var prefixDecoder = function(prefix, value){
+    var parts = value.split(' ');
+
+    var prefixed = parts.map(function(part){
+        if (KNOWN_DECODERS.indexOf(part)){
+            return part;
+        }
+
+        return prefix + capitalize(part);
+    });
+
+    return prefixed.join(parts);
+};
+
+var suffixDecoder = function(prefix, value){
+    var parts = value.split(' ');
+
+    var suffix = parts.map(function(part){
+        if (KNOWN_DECODERS.indexOf(part)){
+            return part;
+        }
+
+        return prefix + capitalize(part);
+    });
+
+    return suffix.join(parts);
+};
+
+export function createDecoder(alias, has_snakecase?, prefix?, suffix?) {
+    var string = alias.replace(/\\n/g, '');
+    var typeName = getTypeAliasName(string);
+
+    var fields = getFields(string).map(function(v){
+        var obj = fieldNameAndType(v);
+        var name = obj.name;
+        var type = makeGuessAtDecoder(obj.type);
+
+        return `|: ("${name}") := ${type}))`;
+    }).join('\n        ');
+
+
+    let output = `decode${typeName} : Decoder ${typeName}\ndecode${typeName} =\n    succeed ${typeName}\n        ${fields}`;
+
+    return output.trim();
+};
+
+
+
+export function createEncoder(alias, has_snakecase?, prefix?, suffix?){
+    var string = alias.replace(/\\n/g, '');
+    var typeName = getTypeAliasName(string);
+
+    var fields = getFields(string).map(function(v){
+        var obj = fieldNameAndType(v);
+        var name = obj.name;
+        var type = makeGuessAtDecoder(obj.type).split(' ').join(' <| ');
+        var originalName = name;
+
+        return `("${name}", ${type} record.${originalName})`;
+    }).join('\n        , ');
+
+    var output = `encode${typeName} : ${typeName}`;
+    output += `Json.Encode.Value\nencode${typeName} record =\n    object\n        [ ${fields}\n        ]`;
+
+    return output.trim();
+};
+
+export function createEverything(string, name, generateAlias: boolean, generatorType: GeneratorType){
+    var json = JSON.parse(string);
+    var output = [];
+
+    createTypeAlias(json, name).map(function(alias){
+      if (generateAlias) {
+        output.push('{-\nGenerated type alias\n-}')
+        output.push(alias);
+      }
+      if (generatorType == GeneratorType.Decoder) {
+        output.push('{-\nGenerated decoder\n-}')
+        output.push(createDecoder(alias));
+      }
+      else {
+        output.push('{-\nGenerated encoder\n-}')
+        output.push(createEncoder(alias));
+      }
+    });
+
+    return output.join('\n')
+};

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -6,6 +6,7 @@ import {activateMake} from './elmMake';
 //import {activateMakeWarn} from './elmMakeWarn';
 import {activatePackage} from './elmPackage';
 import {activateClean} from './elmClean';
+import {activateJson} from './elmJson';
 import {ElmDefinitionProvider} from './elmDefinition';
 import {ElmHoverProvider} from './elmInfo';
 import {ElmCompletionProvider} from './elmAutocomplete';
@@ -32,6 +33,7 @@ export function activate(ctx: vscode.ExtensionContext) {
   activatePackage().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
   activateClean().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
   activateCodeActions().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
+  activateJson().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
 
   let workspaceProvider = new ElmWorkspaceSymbolProvider(ELM_MODE);
 


### PR DESCRIPTION
I'm trying to work out how we can improve editor tooling for json encoding/decoding. This is a demo of functionality so far:

![json-to-elm](https://user-images.githubusercontent.com/367175/27509629-9ddbf3cc-5901-11e7-8890-2aa4c4eb5577.gif)

I've copied @eeue56 json-to-elm initial javascript implementation as a starting point as I couldn't find any npm package - @eeue56 - what's the best way to use json-to-elm as a library?

Functionality as show in video is that user can select any valid json and start the vscode command "Elm create json decoder" (Shortcut: Ctrl+Shift+P ..and type ej). Use can then input toplevel alias and choose output location (new file/existing file/current file).

Is there any other improvements we can make here? It would be ok to be able to hook up to any existing type alias/complex types to improve the generated code. Maybe another approach could be that the user selects an existing toplevel type alias, and have the editor generate decoders based on this structure.

If anyone wants to try this out, it's easy to test this extension and PR - Clone the PR, run npm install, open project in vscode and press F5 to launch a separate vscode instance with this PR.
