### PR TITLE
Jump to symbol based on imports. Jump to symbol that has been fully qualified.

### DIFF
--- a/src/elmDefinition.ts
+++ b/src/elmDefinition.ts
@@ -13,24 +13,63 @@ export function definitionLocation(
   let wordRange = document.getWordRangeAtPosition(position);
   let lineText = document.lineAt(position.line).text;
   let word = wordRange ? document.getText(wordRange) : '';
+  let imports: { [key: string]: string[] } = document.getText().split('\n')
+    .filter(x => x.startsWith('import '))
+    .map(x => x.match(/import ([^\s]+)(?: as [^\s]+)?(?: exposing (\(.+\)))?/))
+    .filter(x => x)
+    .reduce((acc, matches) => {
+      const importedMembers = matches[2] || '()';
+      acc[matches[1]] = importedMembers === '(..)'
+        ? ['*'] : importedMembers.split(/[(),]/).map(x => x.trim()).filter(x => x === '');
+      return acc;
+    }, {});
 
   // also check keywords, in-string etc.
   if (!wordRange || lineText.startsWith('--') || word.match(/^\d+.?\d+$/)) {
     return Promise.resolve(null);
   }
-  return workspaceSymbolProvider.provideWorkspaceSymbols(word, null).then(
-    definitions => {
-      if (definitions == null) {
+
+  let lastWordPart = word.substring(word.lastIndexOf('.') + 1);
+  let wordContainerName = word.substring(0, word.lastIndexOf('.'));
+
+  return workspaceSymbolProvider.provideWorkspaceSymbols(lastWordPart, null).then(
+    symbols => {
+      if (symbols == null) {
         return Promise.resolve(null);
       }
-      let filteredDefinitions = definitions.filter(
-        (val, index, arr) => val.name === word,
-      );
-      if (filteredDefinitions.length > 0) {
-        return filteredDefinitions[0];
-      } else {
-        return Promise.resolve(null);
+      let matchingSymbols = symbols
+        .filter(s => s.name === lastWordPart)
+        .map(s => {
+          const importedMembers = imports[s.containerName] || [];
+
+          return {
+            matchesExactly: wordContainerName && wordContainerName !== '' && s.containerName === wordContainerName,
+            inThisDocument: s.location.uri === document.uri,
+            matchesImportedName: importedMembers.indexOf(s.name) >= 0,
+            possibleMatch: importedMembers.indexOf('*') >= 0,
+            definition: s,
+          };
+        });
+
+      function* findMatch () {
+        yield matchingSymbols.find(m => m.matchesExactly);
+
+        yield matchingSymbols.find(m => m.inThisDocument);
+
+        yield matchingSymbols.find(m => m.matchesImportedName);
+
+        yield matchingSymbols.find(m => m.possibleMatch);
+
+        yield matchingSymbols[0];
       }
+
+      for (let match of findMatch()) {
+        if (match) {
+          return match.definition;
+        }
+      }
+
+      return Promise.resolve(null);
     },
     err => {
       return Promise.resolve(null);


### PR DESCRIPTION
This now supports jumping to a symbol that is fully qualified e.g. MyModule.myFunction fixes #178.

In situations where there are many symbols with the same name such as Model or Msg it will jump to one in the same file, then by imported name, then by import (..), then by symbol name.

This could definitely use more  👀 before a merge.