### PR TITLE
Support elm code syntax highlighting in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For Windows
 
 ### Syntax highlighting
 
-Syntax highlighting is essential. The full language is supported. Can we improve the highlighting further? Please create an [issue](https://github.com/sbrink/vscode-elm/issues)!
+Syntax highlighting is essential. The full language is supported. Fenced code blocks in markdown files are highlighted too. Can we improve the highlighting further? Please create an [issue](https://github.com/sbrink/vscode-elm/issues)!
 
 ### Error highlighting
 

--- a/package.json
+++ b/package.json
@@ -250,6 +250,14 @@
     ],
     "grammars": [
       {
+        "scopeName": "markdown.elm.codeblock",
+        "path": "./syntaxes/codeblock.json",
+        "injectTo": ["text.html.markdown"],
+        "embeddedLanguages": {
+          "meta.embedded.block.elm": "elm"
+        }
+      },
+      {
         "language": "elm",
         "scopeName": "source.elm",
         "path": "./syntaxes/elm.json"

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#fenced_code_block_elm"
+    }
+  ],
+  "repository": {
+    "fenced_code_block_elm": {
+      "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(elm)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language"
+        },
+        "6": {
+          "name": "fenced_code.block.language.attributes"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.elm",
+          "patterns": [
+            {
+              "include": "source.elm"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.elm.codeblock"
+}


### PR DESCRIPTION
Closes #185 

Inspired by:

* https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example
* https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example/issues/2
* https://github.com/Microsoft/vscode/blob/master/extensions/markdown/syntaxes/markdown.tmLanguage.json

This is my fist PR to the VSCode ecosystem, so sorry in advance if I've missed anything. Please check my changes carefully.