### PR TITLE
Fix cursor moving when formatting with elm-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,14 @@ Want to know more? Look at the [snippet definitions](snippets/elm.json)
 
 [elm-format](https://github.com/avh4/elm-format) is supported via the editor's `Format Code` command. To format your code using `elm-format`, press `Shift+Alt+F` on Windows, `Shift+Option+F` on Mac, or `Ctrl+Shift+I` on Linux.
 
-You can also configure `elm-format` to run on save by enabling the `elm.formatOnSave` in your settings.
+You can also configure `elm-format` to run on save by enabling `editor.formatOnSave` in your settings.
 
 ```
 // settings.json
 {
-    "elm.formatOnSave": true
+    "[elm]": {
+        "editor.formatOnSave": true
+    }
 }
 ```
 

--- a/src/elmFormat.ts
+++ b/src/elmFormat.ts
@@ -32,31 +32,6 @@ export class ElmFormatProvider
   }
 }
 
-const ignoreNextSave = new WeakSet<vscode.TextDocument>();
-export function runFormatOnSave(
-  document: vscode.TextDocument,
-  statusBarItem: StatusBarItem,
-): Thenable<vscode.TextEdit[]> {
-  statusBarItem.hide();
-  if (document.languageId !== 'elm' || ignoreNextSave.has(document)) {
-    return;
-  }
-  const showError = statusBarMessage(statusBarItem);
-  const config = vscode.workspace.getConfiguration('elm');
-  const active = vscode.window.activeTextEditor;
-
-  if (config['formatOnSave'] && active.document === document) {
-    const provider = new ElmFormatProvider(statusBarItem);
-    ignoreNextSave.add(document);
-    return provider
-      .provideDocumentFormattingEdits(document)
-      .then(edits => {
-        ignoreNextSave.delete(document);
-        return edits;
-      });
-  }
-}
-
 function elmFormat(document: vscode.TextDocument) {
   const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
     'elm',

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { ElmCodeActionProvider, activateCodeActions } from './elmCodeAction';
-import { ElmFormatProvider, runFormatOnSave } from './elmFormat';
+import { ElmFormatProvider } from './elmFormat';
 import { activateReactor, deactivateReactor } from './elmReactor';
 
 import { ElmCompletionProvider } from './elmAutocomplete';
@@ -29,11 +29,6 @@ export function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(
     vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
       runLinter(document, elmAnalyse);
-    }),
-  );
-  ctx.subscriptions.push(
-    vscode.workspace.onWillSaveTextDocument((documentWillSaveEvent: vscode.TextDocumentWillSaveEvent) => {
-      documentWillSaveEvent.waitUntil(runFormatOnSave(documentWillSaveEvent.document, elmFormatStatusBar));
     }),
   );
   activateRepl().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));


### PR DESCRIPTION
Fixes #182

The extension now relies on VSCode's formatting configuration `editor.formatOnSave` and removes the elm extension specific one `elm.formatOnSave`. (users with `elm.formatOnSave` will need to manually change to `editor.formatOnSave` when upgrading)

It also removes the handler for `willSaveTextDocument`, and now relies solely on the formatter registration mechanism.