### PR TITLE
Fixed issue with elm-make erroring when spaces were in the path

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -53,6 +53,9 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
     const cwd: string =
       utils.detectProjectRoot(filename) || vscode.workspace.rootPath;
     let make: cp.ChildProcess;
+    if (utils.isWindows) {
+      filename = "\"" + filename + "\""
+    }
     const args = [filename, '--report', 'json', '--output', '/dev/null'];
     if (utils.isWindows) {
       make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });

--- a/src/elmMake.ts
+++ b/src/elmMake.ts
@@ -29,6 +29,10 @@ function execMake(editor: vscode.TextEditor, warn: boolean): void {
       file = path.resolve(cwd, specialFile);
     }
 
+    if (utils.isWindows) {
+      file = "\"" + file + "\""
+    }
+
     let args = [file, '--yes', '--output=' + name];
     if (warn) {
       args.push('--warn');


### PR DESCRIPTION
Fixes issue #75 

I just surrounded the filepaths with quotes. I only did this for windows machines as it seemed it was only an issue on windows machines.