### PR TITLE
[Live Share] Limiting workspace symbols and linting to local files

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -129,7 +129,7 @@ export function runLinter(
   document: vscode.TextDocument,
   elmAnalyse: ElmAnalyse,
 ): void {
-  if (document.languageId !== 'elm') {
+  if (document.languageId !== 'elm' || document.uri.scheme !== 'file') {
     return;
   }
   let compileErrors: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -93,7 +93,8 @@ export function activate(ctx: vscode.ExtensionContext) {
   vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
     if (
       document === vscode.window.activeTextEditor.document &&
-      document.languageId === ELM_MODE.language
+      document.languageId === ELM_MODE.language &&
+      document.uri.scheme === ELM_MODE.scheme
     ) {
       workspaceProvider.update(document);
     }


### PR DESCRIPTION
This PR simply restricts the workspace symbols and diagnostic providers to local files, which is already the existing behavior for all other language services (e.g. hover, completion). Additionally, this benefits [Visual Studio Live Share](http://aka.ms/vsls), which already takes care of "remoting" language services from the "host" to the "guest", and therefore, doesn't require the guest (whose files would appear using the `vsls` scheme, not `file`) to perform language services as well.

// CC @Krzysztof-Cieslak 