### PR TITLE
Make linting work again with elm-analyse 0.14.2

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -4,15 +4,17 @@ import * as utils from './elmUtils';
 import * as vscode from 'vscode';
 import { ElmAnalyse } from './elmAnalyse';
 
+export interface IElmIssueRegion {
+  start: { line: number; column: number };
+  end: { line: number; column: number };
+}
+
 export interface IElmIssue {
   tag: string;
   overview: string;
   subregion: string;
   details: string;
-  region: {
-    start: { line: number; column: number };
-    end: { line: number; column: number };
-  };
+  region: IElmIssueRegion;
   type: string;
   file: string;
 }


### PR DESCRIPTION
Solves #184

The communication is now updated to the new message format. Because it provides the description so the hardcoded message description list got removed. Also it does not stop anymore on the first parsing error and gives a list of all message parsing errors. The errors gives a hint that we expect at least the version 0.14.2.

For everyone with an old elm-analyse version this box will be shown to the user in the bottom right corner:
![image](https://user-images.githubusercontent.com/7803088/39384155-1b42b4f2-4a6c-11e8-9559-0cf1f5197729.png)
If the message format changes again this thing will come too.

One thing what i noticed: The description provided by the message format contains the line and column numbers which are lower by 1 compared to the numbers in vscode.
![image](https://user-images.githubusercontent.com/7803088/39383776-d145fedc-4a6a-11e8-8890-46ec2e60003c.png)
