### PR TITLE
Snippets: Add todo comment snippet

### DIFF
--- a/snippets/elm.json
+++ b/snippets/elm.json
@@ -359,6 +359,11 @@
         "        $0"
       ],
       "description": "test block in Elm-test"
+    },
+    "todo": {
+      "prefix": "todo",
+      "body": "-- TODO: $0",
+      "description": "TODO comment"
     }
   }
 }


### PR DESCRIPTION
I'm using this a lot while coding. It's also highlighted in many editors and can be searched.

`todo` will be ` -- TODO: <cursor>` on `<TAB>`.

Would be great to have this snippet available in the plugin.