### PR TITLE
Snippets: Let expression indentation (elm-format)

### DIFF
--- a/snippets/elm.json
+++ b/snippets/elm.json
@@ -207,7 +207,7 @@
         "let",
         "    $1",
         "in",
-        "    $2"
+        "$0"
       ],
       "description": "Let expression"
     },


### PR DESCRIPTION
Changes the snippet for the let expression to be consistent with the way, elm-format is doing it.
<https://github.com/avh4/elm-format/issues/350>