### PR TITLE
Add ability to configure elm-package locating.

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,12 @@
           "type": "boolean",
           "default": false,
           "description": "Enable or disable elm-analyse on startup."
+        },
+        "elm.useWorkSpaceRootForElmRoot": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable trying to detect elm-package from the current file and just use the VSCode workspace's root as the location of elm-package.json."
+
         }
       }
     },

--- a/src/elmUserProject.ts
+++ b/src/elmUserProject.ts
@@ -160,7 +160,8 @@ export function userProject(
   let imports: Imports[] = [];
   let results: IOracleResult[] = [];
 
-  const cwd = detectProjectRoot(document.fileName) || vscode.workspace.rootPath;
+  const cwd = config['useWorkSpaceRootForElmRoot'] ? vscode.workspace.rootPath : detectProjectRoot(document.fileName) || vscode.workspace.rootPath
+
   gCwd = cwd;
   const elmPackageString: string = fs.readFileSync(
     path.join(cwd, 'elm-package.json'),


### PR DESCRIPTION
We have an issue where we have two `elm-package.json` files, and
detecting the right one from the current file doesn't seem to work
correctly and syntax highlighting breaks (and I'm not sure why).

Enabling this to be configured via an option which lets me tell the Elm
plugin to always use `vscode.workspace.root` seems to fix this, so I
thought I'd throw up a PR with this and see what you think :)