### PR TITLE
Fix for Elm 0.19, find right project directory

### DIFF
--- a/src/elmUtils.ts
+++ b/src/elmUtils.ts
@@ -151,7 +151,7 @@ export function findProjAndElmVersion(dir: string): [string, string] {
 export function findProj(dir: string): string {
   if (fs.lstatSync(dir).isDirectory()) {
     const files = fs.readdirSync(dir);
-    const file = files.find((v, i) => v === 'elm-package.json');
+    const file = files.find((v, i) => v === 'elm-package.json' || v === 'elm.json');
     if (file !== undefined) {
       return dir + path.sep + file;
     }


### PR DESCRIPTION
I found this bug because I had an `elm-package.json` in my `~` directory, so when it tried to find the project dir for my Elm 0.19 project, it traversed upwards to my home dir, and then started indexing all files in my home directory for modules. This lead to the editor being unresponsive for a number of seconds.