### PR TITLE
Make compiler errors a little easier to read

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -59,7 +59,7 @@ function parseErrorsElm019(line) {
         details: problem.message
           .map(
             message =>
-              typeof message === 'string' ? message : message.string
+              typeof message === 'string' ? message : '#' + message.string + '#'
           )
           .join(''),
         region: problem.region,


### PR DESCRIPTION
I had a hard time reading the errors from Elm 0.19, because it uses color to signal the relevant information. However, it seems we can't have color in the vscode.Diagnostic, so I propose we put '#' around all parts of compiler errors that are decorated.