### PR TITLE
Fixes to omit Elm Oracle for 0.19 and read elm.json

### DIFF
--- a/src/elmOracle.ts
+++ b/src/elmOracle.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as userProject from './elmUserProject';
 import * as vscode from 'vscode';
 
-import { detectProjectRoot, pluginPath } from './elmUtils';
+import { detectProjectRoot, pluginPath, detectProjectRootAndElmVersion } from './elmUtils';
 
 export interface IOracleResult {
   name: string;
@@ -40,7 +40,7 @@ export function GetOracleResults(
   return new Promise((resolve: Function, reject: Function) => {
     let p: cp.ChildProcess;
     let filename: string = document.fileName;
-    let cwd = detectProjectRoot(document.fileName) || vscode.workspace.rootPath;
+    let [cwd, elmVersion] = detectProjectRootAndElmVersion(document.fileName, vscode.workspace.rootPath) || vscode.workspace.rootPath;
     let fn = path.relative(cwd, filename);
     let wordAtPosition = document.getWordRangeAtPosition(position);
     if (!wordAtPosition) {
@@ -48,27 +48,41 @@ export function GetOracleResults(
     }
     let currentWord: string = document.getText(wordAtPosition);
 
-    p = cp.execFile(
-      'node',
-      [oraclePath, fn, currentWord],
-      { cwd: cwd },
-      (err: Error, stdout: string, stderr: string) => {
-        try {
-          if (err) {
-            return resolve(null);
-          }
+    if (elmVersion === '0.18') {
 
-          const result: IOracleResult[] = [
-            ...JSON.parse(stdout),
-            ...(config['userProjectIntellisense']
-              ? userProject.userProject(document, position, currentWord, action)
-              : []),
-          ];
-          resolve(result);
-        } catch (e) {
-          reject(e);
-        }
-      },
-    );
+      p = cp.execFile(
+        'node',
+        [oraclePath, fn, currentWord],
+        { cwd: cwd },
+        (err: Error, stdout: string, stderr: string) => {
+          try {
+            if (err) {
+              return resolve(null);
+            }
+
+            const result: IOracleResult[] = [
+              ...JSON.parse(stdout),
+              ...(config['userProjectIntellisense']
+                ? userProject.userProject(document, position, currentWord, action)
+                : []),
+            ];
+            resolve(result);
+          } catch (e) {
+            reject(e);
+          }
+        },
+      );
+    } else {
+      try {
+        const result: IOracleResult[] = [
+          ...(config['userProjectIntellisense']
+            ? userProject.userProject(document, position, currentWord, action)
+            : []),
+        ];
+        resolve(result);
+      } catch (e) {
+        reject(e);
+      }
+    }
   });
 }


### PR DESCRIPTION
This fix only uses elm-oracle for 0.18. For user project source (symbols/hover), it also reads the new elm.json file for 0.19