### PR TITLE
Use terminal for elm package install

### DIFF
--- a/src/elmRepl.ts
+++ b/src/elmRepl.ts
@@ -15,35 +15,13 @@ function getElmRepl(): string {
   return replCommand;
 }
 
-function isPowershell() {
-  try {
-    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
-    const t: string = <string>config.get('terminal.integrated.shell.windows');
-    return t.toLowerCase().includes('powershell');
-
-  } catch (error) {
-    return false;
-  }
-}
-
-
-function getReplLaunchCommands(replCommand: string): [string, string] {
-  if (utils.isWindows) {
-    if (isPowershell()) {
-      return [`cmd /c ${replCommand}`, 'clear'];
-
-    } else {
-      return [`${replCommand}`, 'cls'];
-    }
-  } else { return [replCommand, 'clear']; }
-}
 
 function startRepl() {
   try {
     let replCommand = getElmRepl();
     if (replTerminal !== undefined) { replTerminal.dispose(); }
     replTerminal = window.createTerminal('Elm repl');
-    let [replLaunchCommand, clearCommand] = getReplLaunchCommands(replCommand);
+    let [replLaunchCommand, clearCommand] = utils.getTerminalLaunchCommands(replCommand);
     replTerminal.sendText(clearCommand, true);
     replTerminal.sendText(replLaunchCommand, true);
     replTerminal.show(true);

--- a/src/elmUtils.ts
+++ b/src/elmUtils.ts
@@ -199,5 +199,28 @@ export function getIndicesOf(searchStr: string, str: string): number[] {
   return indices;
 }
 
+
+function isPowershell() {
+  try {
+    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
+    const t: string = <string>config.get('terminal.integrated.shell.windows');
+    return t.toLowerCase().includes('powershell');
+
+  } catch (error) {
+    return false;
+  }
+}
+
+export function getTerminalLaunchCommands(command: string): [string, string] {
+  if (isWindows) {
+    if (isPowershell()) {
+      return [`cmd /c ${command}`, 'clear'];
+
+    } else {
+      return [`${command}`, 'cls'];
+    }
+  } else { return [command, 'clear']; }
+}
+
 export const pluginPath = vscode.extensions.getExtension('sbrink.elm')
   .extensionPath;


### PR DESCRIPTION
Since Elm 0.19 command for package install does not support a --yes argument, by using the terminal, the user can input y/n to confirm package install. Closes #246 