### PR TITLE
Setting and logic to disable linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
       "type": "object",
       "title": "Elm configuration",
       "properties": {
+        "elm.disableLinting": {
+          "type": "boolean",
+          "default": false,
+          "description": "Set this setting to true to disable linter if performance is degraded when another elm compiler is running."
+        },
         "elm.reactorHost": {
           "type": "string",
           "default": "127.0.0.1",

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -20,6 +20,8 @@ import { ElmWorkspaceSymbolProvider } from './elmWorkspaceSymbols';
 import { configuration } from './elmConfiguration';
 
 const ELM_MODE: vscode.DocumentFilter = { language: 'elm', scheme: 'file' };
+const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration( 'elm');
+const disableLinter: boolean = <boolean>config.get('disableLinting');
 const elmAnalyseIssues: IElmIssue[] = [];
 const elmAnalyse = new ElmAnalyse(elmAnalyseIssues);
 // this method is called when your extension is activated
@@ -27,11 +29,13 @@ export function activate(ctx: vscode.ExtensionContext) {
   const elmFormatStatusBar = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
   );
-  ctx.subscriptions.push(
-    vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
-      runLinter(document, elmAnalyse);
-    }),
-  );
+  if (!disableLinter) {
+    ctx.subscriptions.push(
+      vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
+        runLinter(document, elmAnalyse);
+      }),
+    );
+  }
   activateRepl().forEach((d: vscode.Disposable) => ctx.subscriptions.push(d));
   activateReactor().forEach((d: vscode.Disposable) =>
     ctx.subscriptions.push(d),


### PR DESCRIPTION
As discussed in #261, linting can cause performance issues. With this setting the user can disable linting when compilation and error reporting is done by other tools.