### PR TITLE
Fix inefficient regex to parse imports

### DIFF
--- a/src/elmDefinition.ts
+++ b/src/elmDefinition.ts
@@ -20,7 +20,7 @@ export function definitionLocation(
     .reduce((acc, matches) => {
       const importedMembers = matches[2] || '()';
       acc[matches[1]] = importedMembers === '(..)'
-        ? ['*'] : importedMembers.split(/[(),]/).map(x => x.trim()).filter(x => x === '');
+        ? ['*'] : importedMembers.split(/[(),]/).map(x => x.trim()).filter(x => x !== '');
       return acc;
     }, {});
 

--- a/src/elmDelphi.ts
+++ b/src/elmDelphi.ts
@@ -50,21 +50,26 @@ function readFile(filePath: string) {
 }
 
 function parseImports(elmCode: string) {
-  let regex = /^import\s+([\w\.]+)(?:\s+as\s+(\w+))?(?:\s+exposing\s+\(((?:[\w\.]+(?:,\s*)?)+)\))?$/gm;
-  let imports = [];
+  return elmCode
+    .split('\n')
+    .filter(x => x.startsWith('import '))
+    .map(x => x.match(/import ([^\s]+)(?: as ([^\s]+))?(?: exposing (\(.+\)))?/))
+    .filter(x => x != null)
+    .map(matches => {
+      const importedMembers = matches[3];
+      const exposed = importedMembers === undefined
+        ? null
+        : importedMembers
+          .split(/[(),]/)
+          .map(x => x.trim())
+          .filter(x => x !== '');
 
-  let myArray;
-  while ((myArray = regex.exec(elmCode)) !== null) {
-    const moduleName = myArray[1];
-    const alias = myArray[2];
-    const exposing = myArray[3];
-    imports.push({
-      moduleName: moduleName,
-      alias: alias || moduleName,
-      exposed: exposing === undefined ? null : exposing.split(',').map(str => str.trim()),
+      return {
+        moduleName: matches[1],
+        alias: matches[2] || matches[1],
+        exposed: exposed,
+      };
     });
-  }
-  return imports;
 }
 
 function getAllDependenciesFromElmJson(elmPath: string) {


### PR DESCRIPTION
I believe this may be the reason for the 100% CPU usage. 

This solution is meant to get VSCode working again and not a complete solution. This solution does not do the following things:

1. Stop looking for imports once statements begin.
2. Properly handle multi-line imports.
3. Properly handle exposing type constructors in an import. 

Considering there are a few places that need to parse Elm file imports there should be a well tested utility or a fully implemented parser.

Here's an example of input that causes the original regex to perform poorly.

https://jsfiddle.net/7v6ahsr3/

An example of output:

```
VM120:49 Match # 1  Duration:  0
12:47:18.251 VM120:49 Match # 2  Duration:  0
12:47:18.251 VM120:49 Match # 3  Duration:  0
12:47:18.251 VM120:49 Match # 4  Duration:  0
12:47:18.251 VM120:49 Match # 5  Duration:  0
12:47:18.251 VM120:49 Match # 6  Duration:  0
12:47:18.251 VM120:49 Match # 7  Duration:  0
12:47:18.252 VM120:49 Match # 8  Duration:  0
12:47:18.252 VM120:49 Match # 9  Duration:  0
12:47:18.252 VM120:49 Match # 10  Duration:  0
12:47:18.252 VM120:49 Match # 11  Duration:  0
12:47:18.252 VM120:49 Match # 12  Duration:  0
12:47:18.252 VM120:49 Match # 13  Duration:  0
12:47:18.253 VM120:49 Match # 14  Duration:  0
12:47:18.253 VM120:49 Match # 15  Duration:  0
12:47:18.253 VM120:49 Match # 16  Duration:  0
12:47:18.253 VM120:49 Match # 17  Duration:  0
12:47:18.253 VM120:49 Match # 18  Duration:  0
12:47:18.254 VM120:49 Match # 19  Duration:  0
12:47:18.293 VM120:49 Match # 20  Duration:  39
12:47:18.293 VM120:49 Match # 21  Duration:  0
12:47:18.293 VM120:49 Match # 22  Duration:  0
12:47:18.293 VM120:49 Match # 23  Duration:  0
12:47:58.063 VM120:49 Match # 24  Duration:  39769
12:47:58.063 VM120:49 Match # 25  Duration:  0
12:47:58.063 VM120:49 Match # 26  Duration:  0
12:47:58.063 VM120:49 Match # 27  Duration:  0
12:47:58.063 VM120:49 Match # 28  Duration:  0
12:47:58.064 VM120:49 Match # 29  Duration:  0
12:47:58.064 VM120:49 Match # 30  Duration:  0
12:47:58.064 VM120:49 Match # 31  Duration:  0
12:47:58.064 VM120:49 Match # 32  Duration:  0
12:47:58.064 VM120:49 Match # 33  Duration:  0
12:47:58.064 VM120:49 Match # 34  Duration:  0
```