### PR TITLE
Elm json support

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,11 +281,11 @@
     "jsonValidation": [
       {
         "fileMatch": "elm.json",
-        "url": "./schemas/elm-package.schema.json"
+        "url": "./schemas/elm.schema.json"
       },
       {
         "fileMatch": "elm-package.json",
-        "url": "./schemas/elm.schema.json"
+        "url": "./schemas/elm-package.schema.json"
       }
     ]
   },
@@ -304,7 +304,8 @@
     "onCommand:elm.browsePackage",
     "onCommand:elm.analyseStart",
     "onCommand:elm.analyseStop",
-    "onCommand:elm.clean"
+    "onCommand:elm.clean",
+    "onLanguage:json"
   ],
   "main": "./out/src/elmMain",
   "scripts": {
@@ -318,12 +319,13 @@
   },
   "devDependencies": {
     "typescript": "^2.4.0",
-    "vscode": "1.1.0"
+    "vscode": "1.1.21"
   },
   "dependencies": {
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.50",
     "elm-oracle": "^0.2.0",
+    "jsonc-parser": "^2.0.2",
     "mocha": "^2.3.3",
     "prettier": "^1.5.3",
     "request": "^2.69.0",

--- a/package.json
+++ b/package.json
@@ -304,8 +304,7 @@
     "onCommand:elm.browsePackage",
     "onCommand:elm.analyseStart",
     "onCommand:elm.analyseStop",
-    "onCommand:elm.clean",
-    "onLanguage:json"
+    "onCommand:elm.clean"
   ],
   "main": "./out/src/elmMain",
   "scripts": {
@@ -319,13 +318,12 @@
   },
   "devDependencies": {
     "typescript": "^2.4.0",
-    "vscode": "1.1.21"
+    "vscode": "1.1.0"
   },
   "dependencies": {
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.50",
     "elm-oracle": "^0.2.0",
-    "jsonc-parser": "^2.0.2",
     "mocha": "^2.3.3",
     "prettier": "^1.5.3",
     "request": "^2.69.0",

--- a/package.json
+++ b/package.json
@@ -277,6 +277,16 @@
         "language": "elm",
         "path": "./snippets/elm.json"
       }
+    ],
+    "jsonValidation": [
+      {
+        "fileMatch": "elm.json",
+        "url": "./schemas/elm-package.schema.json"
+      },
+      {
+        "fileMatch": "elm-package.json",
+        "url": "./schemas/elm.schema.json"
+      }
     ]
   },
   "activationEvents": [

--- a/schemas/elm-package.schema.json
+++ b/schemas/elm-package.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for elm-package.json configuration files",
+  "definitions": {
+    "rangeDependency": {
+      "description": "Dependencies are specified by [author name]/[package name]: [exact version or range]. Range versions look like: [1.0.0 <= v < 2.0.0].",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "repository": {
+      "description": "The project's github url.",
+      "type": "string"
+    },
+    "source-directories": {
+      "description": "A list of directories that will be used to build your project.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "license": {
+      "description": "A license for your package.",
+      "type": "string"
+    },
+    "summary": {
+      "description": "A helpful summary of your package, less than 80 characters",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 79
+    },
+    "version": {
+      "description": "Your package's version in semantic versioning format.",
+      "type": "string",
+      "pattern": "\\d+\\.\\d+\\.\\d+"
+    },
+    "elm-version": {
+      "description": "The version of elm your package is targeting",
+      "type": "string"
+    },
+    "exposed-modules": {
+      "description": "All modules that your project will make available to end users.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "dependencies": {
+      "description": "A list of elm dependencies that your package needs.",
+      "$ref": "#/definitions/rangeDependency"
+    }
+  },
+  "required": [ "repository", "source-directories", "license", "summary", "version", "elm-version", "exposed-modules","dependencies" ],
+  "additionalProperties": true
+}

--- a/schemas/elm.schema.json
+++ b/schemas/elm.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for elm.json configuration files",
+  "definitions": {
+    "exactDependency": {
+      "description": "Dependencies are specified by [author name]/[package name]: [exact version].",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "rangeDependency": {
+      "description": "Dependencies are specified by [author name]/[package name]: [exact version or range]. Range versions look like: [1.0.0 <= v < 2.0.0].",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "packageSpecificProperties": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Specifies if your project will be a package or an application",
+          "type": "string",
+          "enum": ["package"]
+        },
+        "name": {
+          "description": "The name of your package.",
+          "type": "string",
+          "minLength": 1
+        },
+        "license": {
+          "description": "An OSI approved license for your package.",
+          "type": "string",
+          "enum": [ "AFL-1.1", "AFL-1.2", "AFL-2.0", "AFL-2.1", "AFL-3.0", "APL-1.0", "Apache-1.1", "Apache-2.0", "APSL-1.0", "APSL-1.1", "APSL-1.2", "APSL-2.0", "Artistic-1.0", "Artistic-1.0-Perl", "Artistic-1.0-cl8", "Artistic-2.0", "AAL", "BSL-1.0", "BSD-2-Clause", "BSD-3-Clause", "0BSD", "CECILL-2.1", "CNRI-Python", "CDDL-1.0", "CPAL-1.0", "CPL-1.0", "CATOSL-1.1", "CUA-OPL-1.0", "EPL-1.0", "ECL-1.0", "ECL-2.0", "EFL-1.0", "EFL-2.0", "Entessa", "EUDatagrid", "EUPL-1.1", "Fair", "Frameworx-1.0", "AGPL-3.0", "GPL-2.0", "GPL-3.0", "LGPL-2.1", "LGPL-3.0", "LGPL-2.0", "HPND", "IPL-1.0", "Intel", "IPA", "ISC", "LPPL-1.3c", "LiLiQ-P-1.1", "LiLiQ-Rplus-1.1", "LiLiQ-R-1.1", "LPL-1.02", "LPL-1.0", "MS-PL", "MS-RL", "MirOS", "MIT", "Motosoto", "MPL-1.0", "MPL-1.1", "MPL-2.0", "MPL-2.0-no-copyleft-exception", "Multics", "NASA-1.3", "Naumen", "NGPL", "Nokia", "NPOSL-3.0", "NTP", "OCLC-2.0", "OGTSL", "OSL-1.0", "OSL-2.0", "OSL-2.1", "OSL-3.0", "OSET-PL-2.1", "PHP-3.0", "PostgreSQL", "Python-2.0", "QPL-1.0", "RPSL-1.0", "RPL-1.1", "RPL-1.5", "RSCPL", "OFL-1.1", "SimPL-2.0", "Sleepycat", "SISSL", "SPL-1.0", "Watcom-1.0", "UPL-1.0", "NCSA", "VSL-1.0", "W3C", "Xnet", "Zlib", "ZPL-2.0" ]
+        },
+        "summary": {
+          "description": "A helpful summary of your package, less than 80 characters",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 79
+        },
+        "version": {
+          "description": "Your package's version in semantic versioning format.",
+          "type": "string",
+          "pattern": "\\d+\\.\\d+\\.\\d+"
+        },
+        "elm-version": {
+          "description": "The version of elm your package is targeting",
+          "type": "string"
+        },
+        "exposed-modules": {
+          "description": "All modules that your project will make available to end users.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dependencies": {
+          "description": "A list of elm dependencies that your package needs for in production.",
+          "$ref": "#/definitions/rangeDependency"
+        },
+        "test-dependencies": {
+          "description": "A list of elm dependencies that your package uses only for testing.",
+          "$ref": "#/definitions/rangeDependency"
+        }
+      }
+    },
+    "applicationSpecificProperties": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Specifies if your project will be a package or an application",
+          "type": "string",
+          "enum": ["application"]
+        },
+        "source-directories": {
+          "description": "A list of directories that will be used to build your project.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "elm-version": {
+          "description": "The version of elm your project is targeting",
+          "type": "string",
+          "pattern": "\\d+\\.\\d+\\.\\d+",
+          "enum": [ "0.19.0" ]
+        },
+        "dependencies": {
+          "description": "A list of elm dependencies that your project needs for in production.",
+          "type": "object",
+          "properties": {
+            "direct": {
+              "$ref": "#/definitions/exactDependency"
+            },
+            "indirect": {
+              "$ref": "#/definitions/exactDependency"
+            }
+          }
+        },
+        "test-dependencies": {
+          "description": "A list of elm dependencies that your project uses only for testing.",
+          "type": "object",
+          "properties": {
+            "direct": {
+              "$ref": "#/definitions/exactDependency"
+            },
+            "indirect": {
+              "$ref": "#/definitions/exactDependency"
+            }
+          }
+        }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/definitions/applicationSpecificProperties" },
+    { "$ref": "#/definitions/packageSpecificProperties" }
+  ]
+}

--- a/schemas/elm.schema.json
+++ b/schemas/elm.schema.json
@@ -19,11 +19,6 @@
     "packageSpecificProperties": {
       "type": "object",
       "properties": {
-        "type": {
-          "description": "Specifies if your project will be a package or an application",
-          "type": "string",
-          "enum": ["package"]
-        },
         "name": {
           "description": "The name of your package.",
           "type": "string",
@@ -64,16 +59,12 @@
           "description": "A list of elm dependencies that your package uses only for testing.",
           "$ref": "#/definitions/rangeDependency"
         }
-      }
+      },
+      "required": [ "name", "license", "summary", "version", "elm-version", "exposed-modules","dependencies", "test-dependencies" ]
     },
     "applicationSpecificProperties": {
       "type": "object",
       "properties": {
-        "type": {
-          "description": "Specifies if your project will be a package or an application",
-          "type": "string",
-          "enum": ["application"]
-        },
         "source-directories": {
           "description": "A list of directories that will be used to build your project.",
           "type": "array",
@@ -97,7 +88,8 @@
             "indirect": {
               "$ref": "#/definitions/exactDependency"
             }
-          }
+          },
+          "required": [ "direct", "indirect" ]
         },
         "test-dependencies": {
           "description": "A list of elm dependencies that your project uses only for testing.",
@@ -109,13 +101,42 @@
             "indirect": {
               "$ref": "#/definitions/exactDependency"
             }
-          }
+          },
+          "required": [ "direct", "indirect" ]
         }
+      },
+      "required": [ "source-directories", "elm-version","dependencies", "test-dependencies" ]
+    }
+  },
+  "properties": {
+    "type": {
+      "description": "Specifies if your project will be a package or an application",
+      "type": "string",
+      "enum": ["application", "package"]
+    }
+  },
+  "if": {
+    "properties": {
+      "type": {
+        "enum": ["package"]
       }
     }
   },
-  "oneOf": [
-    { "$ref": "#/definitions/applicationSpecificProperties" },
-    { "$ref": "#/definitions/packageSpecificProperties" }
-  ]
+  "then": {
+    "$ref": "#/definitions/packageSpecificProperties"
+  },
+  "else": {
+    "if": {
+      "properties": {
+        "type": {
+          "enum": ["application"]
+        }
+      }
+    },
+    "then": {
+      "$ref": "#/definitions/applicationSpecificProperties"
+    },
+    "else": {}
+  },
+  "required": ["type"]
 }


### PR DESCRIPTION
This requires some more testing, but I think it's about done. It adds some descriptions to the properties and validates that they have the required properties.

This is to my best knowledge (I've tested on my own projects) but I'm not sure if there are any other differences in 0.18. Additionally, I'm not completely sure if you're allowed to add extra properties to elm.json in 0.19. I think 0.18 you are allowed to and it will leave it alone. I seem to recall someone saying that it will remove them in 0.19. For now, it allows additional fields for 0.18 and doesn't for 0.19.

I will continue testing this in different situations. Feedback on the descriptions is especially helpful. Also, let me know if you think there can be even more validation done to the different properties. For instance, we could add more regexes on the string fields.