### PR TITLE
Update local installation instructions for 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ Run `npm install --save-dev elm`
 Then, in `.vscode/settings.json`, add the following:
 
 ```
+"elm.compiler": "./node_modules/.bin/elm",
 "elm.makeCommand": "./node_modules/.bin/elm-make"
 ```
 
 For Windows
 ```
+"elm.compiler": ".\\node_modules\\.bin\\elm",
 "elm.makeCommand": ".\\node_modules\\.bin\\elm-make"
 ```
 


### PR DESCRIPTION
Projects identified as Elm 0.19 will use the `elm.compiler` option instead of the `elm.makeCommand` option.