### PR TITLE
Missing compiler error message

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -190,7 +190,7 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
       errorLinesFromElmMake.close();
       if (err && err.code === 'ENOENT') {
         vscode.window.showInformationMessage(
-          "The 'elm-make' compiler is not available.  Install Elm from http://elm-lang.org/.",
+          `The elm compiler is not available (${makeCommand}). Install Elm from https://elm-lang.org.`,
         );
         resolve([]);
       } else {


### PR DESCRIPTION
The error message was mentioning `elm-make` before. This is only the case for 0.18 and could be misleading. The message is updated and contains the `makeCommand` variable.


##### Context
Trying to help with #294 it was hard to tell that, the plugin wasn't searching for the 0.18 elm compiler.