### PR TITLE
The linter should also respect the module in "Make special path"

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -65,7 +65,7 @@ function parseErrorsElm019(line) {
               typeof message === 'string'
                 ? message
                 : '#' + message.string + '#',
-        )
+          )
           .join(''),
         region: problem.region,
         type: 'error',
@@ -82,7 +82,7 @@ function parseErrorsElm019(line) {
       details: errorObject.message
         .map(
           message => (typeof message === 'string' ? message : message.string),
-      )
+        )
         .join(''),
       region: {
         start: {
@@ -125,9 +125,13 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
       filename,
       vscode.workspace.rootPath,
     );
+    const specialFile: string = <string>config.get('makeSpecialFile');
     const isTestFile = elmTest.fileIsTestFile(filename);
     let make;
 
+    if (specialFile.length > 0) {
+      filename = path.resolve(cwd, specialFile);
+    }
     if (utils.isWindows) {
       filename = '"' + filename + '"';
     }


### PR DESCRIPTION
Currently compilation uses the module defined in `Make special path`, but linting doesn't.  This means that every time you save a file the messages in VSCode only shows the errors in that particular module.  This PR makes sure that messages are shown from the whole project.  If nothing is set in `Make special path` this PR should have no effect.