### PR TITLE
Match test paths platform-independently

### DIFF
--- a/src/elmTest.ts
+++ b/src/elmTest.ts
@@ -2,14 +2,14 @@ import * as utils from './elmUtils';
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-export function fileIsTestFile(filename) {
+export function fileIsTestFile(filename: string) {
   const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
     'elm',
   );
-  const elmTestLocationMatcher: string = <string>(
+  const testMatcher: string = <string>(
     config.get('elmTestFileMatcher')
   );
-  const [cwd, elmVersion] = utils.detectProjectRootAndElmVersion(
+  const [_, elmVersion] = utils.detectProjectRootAndElmVersion(
     filename,
     vscode.workspace.rootPath,
   );
@@ -18,8 +18,13 @@ export function fileIsTestFile(filename) {
     return false;
   }
 
-  const pathFromRoute = path.relative(vscode.workspace.rootPath, filename);
-  const isTestFile = pathFromRoute.indexOf(elmTestLocationMatcher) > -1;
+  const pathFromRoot = path.relative(vscode.workspace.rootPath, filename);
+  const pathParts = path.parse(pathFromRoot);
+  const pathNormalized = path.posix.format(pathParts);
 
+  const testMatcherParts = path.parse(testMatcher);
+  const testMatcherNormalized = path.posix.format(testMatcherParts);
+
+  const isTestFile = pathNormalized.includes(testMatcherNormalized);
   return isTestFile;
 }


### PR DESCRIPTION
At the moment the default value for `elmTestFileMatcher` is `"tests/"` which fails on Windows because of the backslash path delimiter on Windows.

This PR normalizes both the configured `elmTestFileMatcher` and the path we're matching against to POSIX format so that both forward and backslashes will work on any platform. (This matches Node's `path.parse` behaviour too, which will allow either kind of slash on either platform.)