### PR TITLE
Work around a bug in node-test-runner

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -113,7 +113,7 @@ function parseErrorsElm018(line) {
   return <IElmIssue[]>JSON.parse(line);
 }
 
-function checkForErrors(filename): Promise<IElmIssue[]> {
+function checkForErrors(fullFilename): Promise<IElmIssue[]> {
   return new Promise((resolve, reject) => {
     const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
       'elm',
@@ -122,12 +122,14 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
     const compiler: string = <string>config.get('compiler');
     const elmTestCompiler: string = <string>config.get('elmTestCompiler');
     const [cwd, elmVersion] = utils.detectProjectRootAndElmVersion(
-      filename,
+      fullFilename,
       vscode.workspace.rootPath,
     );
     const specialFile: string = <string>config.get('makeSpecialFile');
-    const isTestFile = elmTest.fileIsTestFile(filename);
+    const isTestFile = elmTest.fileIsTestFile(fullFilename);
     let make;
+
+    let filename = path.relative(cwd, fullFilename);
 
     if (specialFile.length > 0) {
       filename = path.resolve(cwd, specialFile);
@@ -135,8 +137,6 @@ function checkForErrors(filename): Promise<IElmIssue[]> {
     if (utils.isWindows) {
       filename = '"' + filename + '"';
     }
-
-
 
     const args018 = [filename, '--report', 'json', '--output', '/dev/null'];
     const args019 = [


### PR DESCRIPTION
There's a bug in elm-test which means that paths to test files are sometimes not recognized

https://github.com/rtfeldman/node-test-runner/issues/316

This PR wrangles the paths to be relative to the project root so elm-test always recognizes them.